### PR TITLE
Switch to a more standard delete icon

### DIFF
--- a/upgrade-planner/gui.lua
+++ b/upgrade-planner/gui.lua
@@ -133,7 +133,7 @@ local function open_frame(player)
   local remove_button = storage_flow.add{
     type = "sprite-button",
     name = "upgrade_planner_storage_delete",
-    sprite = "utility/trash_bin",
+    sprite = "utility/trash",
     tooltip = {"upgrade-planner.delete-storage-button-tooltip"},
   }
   remove_button.style = "red_slot_button"


### PR DESCRIPTION
Use "utility/trash" instead of "utility/trash_bin"

This different icon seems to be a standard icon for denoting delete buttons, it should have better chances of not getting removed in the future.