### PR TITLE
Change broken confirm button style.

### DIFF
--- a/upgrade-planner/gui.lua
+++ b/upgrade-planner/gui.lua
@@ -153,7 +153,7 @@ local function open_frame(player)
     sprite = "utility/confirm_slot",
     tooltip = {"upgrade-planner.confirm-storage-name"},
   }
-  confirm_button.style = "green_slot_button"
+  confirm_button.style = "slot_button"
   confirm_button.style.maximal_width = 24
   confirm_button.style.minimal_width = 24
   confirm_button.style.maximal_height = 24


### PR DESCRIPTION
Hi 👋 

After the latest game update (0.18.28 or maybe already in 0.18.27) using the upgrade planner crashes the game because a button style is used that doesn't seem to exist any more.

I couldn't find a list of all available styles so I don't know if there is a more appropriate one. I've tested the change I'm proposing and it looks fine to me.

I'd appreciate it, if you could merge this and release a new version :)

Kind regards,
yeldiR